### PR TITLE
Appleの公証に対応する

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,2 +1,4 @@
 NODE_ENV=local
 VUE_APP_API_BASE_URL=http://docker-local.milelane.co
+APPLE_ID=your.apple.id@email.com
+APPLE_APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx

--- a/config/notarization/entitlements.mac.plist
+++ b/config/notarization/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milelane",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Masashi Fujiike (https://github.com/MasashiFujiike/)",
   "description": "A treeable task manager.",
   "repository": {
@@ -16,6 +16,7 @@
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
     "electron:generate-icons": "electron-icon-builder --input=./public/icon.png --output=build --flatten",
+    "electron:notarization-history": "xcrun altool --notarization-history 0 -u $APPLE_ID -p $APPLE_APP_SPECIFIC_PASSWORD",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
     "electron:generate-icons": "electron-icon-builder --input=./public/icon.png --output=build --flatten",
+    "electron:notarize": "scripts/notarize.js",
     "electron:notarization-history": "xcrun altool --notarization-history 0 -u $APPLE_ID -p $APPLE_APP_SPECIFIC_PASSWORD",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"
@@ -44,6 +45,7 @@
     "babel-eslint": "^10.0.3",
     "electron": "^6.0.0",
     "electron-icon-builder": "^1.0.0",
+    "electron-notarize": "^0.3.0",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,15 @@
+const { notarize } = require('electron-notarize');
+
+exports.default = async function notarizing(context) {
+    const { appOutDir } = context;
+    const appName = context.packager.appInfo.productFilename;
+
+    console.log('Started notarization request.');
+    await notarize({
+        appBundleId: 'co.milelane.app',
+        appPath: `${appOutDir}/${appName}.app`,
+        appleId: process.env.APPLE_ID,
+        appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+    });
+    console.log('Finished notarization request.');
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,7 +6,11 @@ module.exports = {
         appId: 'co.milelane.app',
         copyright: 'Copyright © 2020 whalepod & Masashi Fujiike.',
         mac: {
-          category: 'public.app-category.productivity'
+          category: "public.app-category.productivity",
+          hardenedRuntime: true,
+          gatekeeperAssess: false,
+          entitlements: "config/notarization/entitlements.mac.plist",
+          entitlementsInherit: "config/notarization/entitlements.mac.plist"
         }
       }
     }

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,7 +11,11 @@ module.exports = {
           gatekeeperAssess: false,
           entitlements: "config/notarization/entitlements.mac.plist",
           entitlementsInherit: "config/notarization/entitlements.mac.plist"
-        }
+        },
+        dmg: {
+          sign: false
+        },
+        afterSign: "scripts/notarize.js"
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,6 +4425,14 @@ electron-icon-builder@^1.0.0:
     icon-gen "^2.0.0"
     jimp "^0.9.3"
 
+electron-notarize@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.3.0.tgz#b93c606306eac558b250c78ff95273ddb9fedf0a"
+  integrity sha512-tuDw8H0gcDOalNLv6RM2CwGvUXU60MPGZRDEmd0ppX+yP5XqL8Ec2DuXyz9J7WQSA3aRCfzIgH8C5CAivDYWMw==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^8.1.0"
+
 electron-publish@21.2.0:
   version "21.2.0"
   resolved "https://registry.npm.taobao.org/electron-publish/download/electron-publish-21.2.0.tgz#cc225cb46aa62e74b899f2f7299b396c9802387d"


### PR DESCRIPTION
## Issue

close #20 

## 使い方

環境変数とかの条件があるので今のところ @MasashiFujiike の持っている apple id でしか実行できないが、

`yarn electron:build`

すると公証までを自動で済ませてくれるようになった