### PR TITLE
タスクリストの最大幅を設定した

### DIFF
--- a/src/components/task/TaskList.vue
+++ b/src/components/task/TaskList.vue
@@ -41,6 +41,8 @@ export default {
 </script>
 <style>
   .task-list {
+    max-width: 800px;
+    margin: 0 auto;
     padding: 12px 12px 49px; /* TaskInputオブジェクトの height 48px + border 1px */
   }
   .task-list-empty-message {


### PR DESCRIPTION
多少見れる感じの幅になった。そもそもの幅が狭ければ問題ない挙動になる。
<img width="1371" alt="Screen Shot 2020-04-04 at 23 53 04" src="https://user-images.githubusercontent.com/8110048/78453916-b2e6cf00-76cf-11ea-822e-0f30496f612e.png">
