### PR TITLE
完了をわかりやすくし、タスクのタイトルが長くても崩れなくした

### DIFF
--- a/src/components/task/TaskItem.vue
+++ b/src/components/task/TaskItem.vue
@@ -6,7 +6,7 @@
       <span v-else-if="id === 0" class="task-item-id task-item-id-error">error</span>
       <span v-else class="task-item-id" :class="{ 'task-item-lane-id': type === 'lane' }">#{{id}}</span>
       <p class="task-item-title" :class="{ 'task-item-lane-title': type === 'lane' }">{{title}}</p>
-      <button v-if="canCompleteTask" class="task-item-complete-button" @click="handleCompleteTask">Done</button>
+      <button v-if="canCompleteTask" class="task-item-complete-button" @click="handleCompleteTask">Complete task</button>
       <div class="task-item-completed" v-else-if="completed_at">✔</div>
       <!-- TODO: Adjust design to enable this having multiple errors. (This may collapse) -->
       <ul v-if="hasErrors" class="task-item-errors">
@@ -109,7 +109,7 @@ export default {
   .task-item {
     position: relative;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: 4px;
     padding: 2px 6px;
     border-radius: 4px;
@@ -120,16 +120,19 @@ export default {
   }
   .task-item-id {
     /* Currently, only 4 digits can be shown. */
+    flex-shrink: 0;
     width: 44px;
     padding: 0 5px;
     background-color: #6ba893;
     border-radius: 4px;
     color: #fff;
     font-size: 10px;
-    line-height: 18px;
+    line-height: 20px;
   }
 
   .task-item-title {
+    -webkit-flex-grow: 1;
+    flex-grow: 1;
     padding-left: 6px;
     line-height: 20px;
     font-size: 11px;
@@ -138,11 +141,10 @@ export default {
   }
   /* Show if not completed. */
   .task-item-complete-button {
-    position: absolute;
-    top: 3px;
-    right: 0;
-    bottom: 3px;
-    width: 56px;
+    flex-shrink: 0;
+    width: 88px;
+    padding: 0 5px;
+    line-height: 20px;
     border-radius: 4px;
     background-color: #558783;
     transition: all .3s;
@@ -158,21 +160,15 @@ export default {
 
   /* Show if completed. */
   .task-item-completed {
-    border-radius: 4px;
+    flex-shrink: 0;
     display: flex;
     justify-content: center;
     align-items: center;
-
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: 56px;
-
+    width: 44px;
+    border-radius: 4px;
+    line-height: 20px;
     background-color: #6ba893;
-
     color: #fff;
-
     font-size: 10px;
   }
   .task-children {
@@ -180,20 +176,19 @@ export default {
   }
 
   /* Show if has errors */
+  /* This class should be used with .task-item-id */
   .task-item-id-error {
     background-color: red;
   }
   .task-item-errors {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    padding: 2px 6px;
+    flex-shrink: 0;
+    padding: 0 6px;
     border: 1px solid red;
     border-radius: 4px;
+    background-color: #fff;
   }
   .task-item-error {
-    line-height: 18px;
+    line-height: 20px;
     font-size: 10px;
     color: red;
   }


### PR DESCRIPTION
## Issue

close #25 
close #36 

## ScreenShot

<img width="381" alt="Screen Shot 2020-04-05 at 0 13 58" src="https://user-images.githubusercontent.com/8110048/78454406-d3fcef00-76d2-11ea-8001-f8af0edb3f28.png">
<img width="800" alt="Screen Shot 2020-04-05 at 0 14 53" src="https://user-images.githubusercontent.com/8110048/78454408-d52e1c00-76d2-11ea-8020-a310dddbdefb.png">

