### PR TITLE
deviceUuidを送るべきところをdeviceTokenを送っていたバグを修正する

### DIFF
--- a/src/modules/api/client.js
+++ b/src/modules/api/client.js
@@ -8,7 +8,7 @@ const client = (options, shouldAuth = true) => {
   }
 
   if (shouldAuth) {
-    headers['X-Device-UUID'] = store.state.device.deviceToken
+    headers['X-Device-UUID'] = store.state.device.deviceUuid
   }
 
   const defaultOptions = {


### PR DESCRIPTION
## Issue

close #59 

API側のバリデーションが効いていなかったのも原因なので追ってこちらも対応する
refs: https://github.com/whalepod/milelane/issues/45